### PR TITLE
add project documentation and GLiNER/GLiNER2 overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,228 @@
+# AGENTS.md
+
+This repository contains **fast_gliner**, Python bindings for the Rust inference engine **gline-rs**, which runs GLiNER models.
+
+The project enables fast CPU/GPU inference for GLiNER models through a Python API while keeping heavy computation in Rust.
+
+This document defines how coding agents should operate within this repository.
+
+---
+
+# Repository Overview
+
+The repository consists of two main components:
+
+```
+fast_gliner
+│
+├── bindings/python
+│   Python package + PyO3 bindings
+│
+└── gline-rs
+    Rust inference engine
+```
+
+Agents must understand the responsibility boundary:
+
+| Layer | Responsibility |
+|------|---------------|
+| Python | User API |
+| PyO3 | FFI bridge |
+| Rust | Inference logic |
+
+---
+
+# Core Principle
+
+Inference logic must remain in Rust.
+
+Python must remain a thin wrapper.
+
+Do NOT implement model logic in Python.
+
+---
+
+# Development Environment
+
+Development setup, build commands, and release procedures are documented in:
+
+[`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md)
+
+Agents should consult that document instead of redefining build instructions here.
+
+---
+
+# Python Layer
+
+Location:
+
+```
+bindings/python
+```
+
+Key Python source:
+
+```
+bindings/python/py_src/fast_gliner
+```
+
+Main class:
+
+```
+FastGLiNER
+```
+
+Responsibilities of the Python layer:
+
+- Loading models (`from_pretrained`)
+- Validating inputs
+- Calling the Rust extension
+- Formatting outputs for users
+
+Python should not perform inference logic.
+
+All heavy computation must remain in Rust.
+
+---
+
+# Rust Inference Engine
+
+Location:
+
+```
+gline-rs/src
+```
+
+Top-level modules:
+
+```
+model/
+text/
+util/
+```
+
+The Rust crate implements the complete GLiNER inference pipeline.
+
+Agents modifying model behavior should work inside this crate.
+
+---
+
+# Inference Architecture
+
+The GLiNER inference pipeline and system design are documented in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+Agents modifying model logic should read that document before changing pipeline code.
+
+---
+
+# Inference Mode
+
+`GLiNER` supports multiple inference modes (e.g. span mode and token mode).
+
+Details about these modes and their pipelines are documented in: [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+---
+
+# Model Runtime
+
+Inference runs through ONNX Runtime via:
+
+```
+orp::model::Model
+```
+
+Agents should not modify runtime behavior unless necessary.
+
+---
+
+# Safe Modification Areas
+
+Agents may safely modify:
+
+```
+gline-rs/src/model/pipeline
+gline-rs/src/model/input
+gline-rs/src/model/output
+```
+
+Agents should avoid modifying:
+
+```
+gline-rs/src/text
+gline-rs/src/util
+```
+
+unless fixing bugs.
+
+---
+
+# Coding Guidelines
+
+Rust
+
+Prefer:
+
+- iterators
+- zero-copy data flow
+- minimal allocations
+
+Avoid:
+
+- cloning large tensors
+- unnecessary heap allocations
+
+Python
+
+Keep Python logic minimal.
+
+Python should:
+
+- load models
+- call Rust functions
+- format results
+
+---
+
+# Backwards Compatibility
+
+Changes must not break the existing Python API:
+
+```
+FastGLiNER.from_pretrained()
+FastGLiNER.predict_entities()
+FastGLiNER.extract_relations()
+```
+
+---
+
+# Upstream Relationship
+
+The Rust engine originates from:
+
+```
+https://github.com/fbilhaut/gline-rs
+```
+
+Agents should inspect upstream implementation before rewriting core logic.
+
+---
+
+# Future Development
+
+Upcoming development plans are tracked in:
+
+[`docs/ROADMAP.md`][`docs/ROADMAP.md`](./docs/ROADMAP.md)
+
+---
+
+# Agent Behavior Guidelines
+
+When implementing features:
+
+1. Modify the Rust engine first
+2. Keep the Python API stable
+3. Avoid duplicating logic across layers
+4. Preserve pipeline composability
+5. Maintain performance characteristics
+
+If uncertain about architecture changes, propose a design before implementing.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,355 @@
+# ARCHITECTURE.md
+
+This document describes the internal architecture of **fast_gliner** and its Rust inference engine.
+
+The goal of the project is to provide **fast CPU/GPU inference for GLiNER models** through a Python API while keeping heavy computation inside Rust.
+
+---
+
+# System Overview
+
+The system consists of four major layers:
+
+Python API
+    ↓
+PyO3 bindings
+    ↓
+Rust GLiNER inference engine
+    ↓
+ONNX Runtime
+    ↓
+GLiNER model
+
+Python exposes a simple API for users, while Rust handles the full inference pipeline and performance‑critical operations.
+
+---
+
+# Repository Structure
+
+```
+fast_gliner
+│
+├── AGENTS.md
+├── ARCHITECTURE.md
+│
+├── bindings/python
+│   Python package and PyO3 bindings
+│
+└── gline-rs
+    Rust inference engine
+```
+
+The repository intentionally vendors the `gline-rs` project instead of using it as an external dependency.
+
+This allows the Python bindings and Rust inference engine to evolve together.
+
+---
+
+# Python Layer
+
+Location:
+
+```
+bindings/python/py_src/fast_gliner
+```
+
+Main class:
+
+```
+FastGLiNER
+```
+
+Responsibilities:
+
+• model loading  
+• API interface for users  
+• validating inputs  
+• calling Rust extension functions  
+• formatting outputs  
+
+The Python layer should remain **thin**.
+
+All heavy computation must remain inside Rust.
+
+---
+
+# Rust Engine
+
+Location:
+
+```
+gline-rs/src
+```
+
+Main modules:
+
+```
+model/
+text/
+util/
+```
+
+The Rust crate implements the full GLiNER inference pipeline.
+
+---
+
+# Pipeline Architecture
+
+Inference is implemented as a **composable processing pipeline**.
+
+Each stage converts data into a new representation until the final entity spans are produced.
+
+High‑level flow:
+
+```
+TextInput
+  ↓
+TokenizedInput
+  ↓
+PromptInput
+  ↓
+EncodedInput
+  ↓
+Tensor preparation
+  ↓
+ONNX Runtime inference
+  ↓
+TensorOutput
+  ↓
+Span decoding
+  ↓
+Greedy filtering
+```
+
+---
+
+# Input Pipeline
+
+## TextInput
+
+Represents raw input text and entity labels.
+
+## TokenizedInput
+
+Word tokenization using RegexSplitter.
+
+## PromptInput
+
+Constructs GLiNER prompts:
+
+```
+<<ENT>> entity1 <<ENT>> entity2 <<SEP>> text tokens
+```
+
+## EncodedInput
+
+Subword tokenization via HuggingFace tokenizer.
+
+Produces tensors:
+
+```
+input_ids  
+attention_mask  
+word_mask  
+text_lengths
+```
+
+---
+
+# Tensor Preparation
+
+Two inference modes exist.
+
+## Span Mode
+
+Used for most GLiNER NER models.
+
+Additional tensors:
+
+```
+span_idx  
+span_mask
+```
+
+## Token Mode
+
+Used for multitask GLiNER models.
+
+Works with token-level logits.
+
+---
+
+# Model Inference
+
+The ONNX model is executed through:
+
+```
+orp::model::Model
+```
+
+Which wraps **ONNX Runtime**.
+
+Execution providers include:
+
+• CPU  
+• CUDA
+
+---
+
+# Output Pipeline
+
+After inference, the model produces:
+
+TensorOutput
+
+This tensor is decoded into entity spans.
+
+---
+
+# Span Decoding
+
+Expected tensor shape:
+
+```
+(batch_size, num_words, max_width, num_classes)
+```
+
+Converted into spans containing:
+
+```
+text  
+label  
+probability  
+start_offset  
+end_offset
+```
+
+---
+
+# Token Decoding
+
+Token mode uses three token logits:
+
+```
+start  
+end  
+inside
+```
+
+These logits are combined to reconstruct spans.
+
+---
+
+# Span Filtering
+
+Decoded spans are filtered using **greedy search**.
+
+Filtering rules:
+
+```
+flat_ner  
+dup_label  
+multi_label
+```
+
+---
+
+# Relation Extraction
+
+Relation extraction builds on top of NER results.
+
+Pipeline:
+
+```
+NER spans
+   ↓
+relation prompts
+   ↓
+token pipeline
+   ↓
+relation decoding
+
+Relations are validated against a schema.
+```
+
+---
+
+# Text Module
+
+The `text` module provides core structures:
+
+```
+Token  
+Span  
+Tokenizer  
+Splitter  
+Prompt
+```
+
+These maintain alignment between tokens and original text offsets.
+
+---
+
+# Utility Module
+
+The `util` module provides shared helpers such as:
+
+• error handling  
+• math utilities  
+• shared result types  
+
+---
+
+# Execution Flow
+
+Typical inference call:
+
+```
+Python FastGLiNER
+      ↓
+Rust PyFastGliNER
+      ↓
+GLiNER pipeline
+      ↓
+ONNX Runtime
+      ↓
+decoded spans
+      ↓
+Python result formatting
+```
+
+---
+
+# Performance Goals
+
+The engine prioritizes:
+
+• minimal allocations  
+• safe Rust code  
+• efficient tensor operations  
+• batch processing  
+
+---
+
+# Extension Points
+
+Future features should primarily modify:
+
+```
+gline-rs/src/model/input
+gline-rs/src/model/output
+gline-rs/src/model/pipeline
+```
+
+These areas define model architecture behavior.
+
+---
+
+# Future Development
+
+Planned improvements include:
+
+• GLiNER2 model support  
+• improved CUDA execution  
+• additional decoding strategies  
+• improved batching support

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Python binding to *gline-rs*, the inference engine for [GLiNER](https://github.c
   - Simple python interface to GLiNER models.
   - [~4x speedup](https://github.com/fbilhaut/gline-rs?tab=readme-ov-file#cpu) compared to the PyTorch implementation.
 
+---
+
 ## ⏳ Installation
 
 ### Pre-built wheel (CPU-only)
@@ -25,6 +27,8 @@ $ pip install --no-binary=:all: fast_gliner
 ```
 $ pip install --no-binary=:all: fast_gliner[cuda]
 ```
+
+---
 
 ## 🚀 Quickstart
 
@@ -101,6 +105,8 @@ Output:
    'end': 94}}]
 ```
 
+---
+
 ## Development
 
 Set up environment
@@ -122,6 +128,30 @@ Release package to PyPI
 $ make
 $ make release
 ```
+
+---
+
+## For Contributors
+
+If you're planning to contribute to `fast_gliner`, the following documents provide useful context:
+
+1. **Start here:**
+   [`docs/GLINER_OVERVIEW.md`](./docs/GLINER_OVERVIEW.md) — background on GLiNER and GLiNER2 models.
+
+2. **Understand the system design:**
+   [`ARCHITECTURE.md`](./ARCHITECTURE.md) — explains how the Python API, Rust inference engine, and ONNX Runtime interact.
+
+3. **Set up your development environment:**
+   [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md) — instructions for building the project and running it locally.
+
+4. **Planned future work:**
+   [`docs/ROADMAP.md`](./docs/ROADMAP.md) — outlines upcoming development phases, including GLiNER2 support.
+
+Coding agents working in this repository should also follow the rules described in:
+
+* [`AGENTS.md`](./AGENTS.md)
+
+---
 
 ## References
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,148 @@
+# DEVELOPMENT.md
+
+This document describes how to develop and modify the `fast_gliner` project.
+
+---
+
+# Project Layout
+
+```
+fast_gliner
+│
+├── AGENTS.md
+├── ARCHITECTURE.md
+│
+├── bindings/python
+│   Python package and PyO3 bindings
+│
+├── gline-rs
+│   Rust inference engine
+│
+└── docs
+```
+
+---
+
+# Development Environment
+
+The project requires:
+
+- Rust
+- Python 3.10+
+- Poetry
+- Maturin
+
+Install Python dependencies:
+
+```sh
+cd bindings/python
+poetry install
+```
+
+---
+
+# Building the Python Extension
+
+To build and install the Rust extension locally:
+
+```sh
+cd bindings/python
+make dev
+```
+
+This command will:
+
+1. Install Python dependencies via Poetry
+2. Compile the Rust extension with `maturin`
+3. Install the module into the Poetry environment
+
+---
+
+# Formatting
+
+Python formatting and linting:
+
+```sh
+make style
+```
+
+This runs `ruff`.
+
+---
+
+# Building Wheels
+
+To build a distributable wheel:
+
+```sh
+make build
+```
+
+---
+
+# CUDA Builds
+
+CUDA support can be enabled with:
+
+```sh
+make FEATURES=cuda build
+```
+
+---
+
+# Rust Development
+
+Rust code lives in:
+
+```
+gline-rs/src
+```
+
+Key areas:
+
+model/      → inference pipelines
+text/       → tokenization and offsets
+util/       → shared helpers
+
+---
+
+# Testing Changes
+
+When modifying inference logic, test:
+
+1. Entity extraction
+2. Relation extraction
+3. CPU execution
+4. CUDA execution (if available)
+
+Example Python test:
+
+```python
+from fast_gliner import FastGLiNER
+
+model = FastGLiNER.from_pretrained(
+    model_id="onnx-community/gliner_multi-v2.1-onnx"
+)
+
+model.predict_entities("Barack Obama lives in Washington", ["person", "location"])
+```
+
+---
+
+# Modifying the Rust Engine
+
+When implementing new model features:
+
+1. Update pipeline stages in `model/pipeline`
+2. Modify tensor input/output logic if needed
+3. Keep Python bindings minimal
+
+---
+
+# Contribution Guidelines
+
+Before implementing large changes:
+
+- propose a design
+- ensure compatibility with the Python API
+- maintain performance characteristics

--- a/docs/GLINER_OVERVIEW.md
+++ b/docs/GLINER_OVERVIEW.md
@@ -1,0 +1,259 @@
+# GLiNER and GLiNER2 Overview
+
+This document provides a high-level overview of the GLiNER family of models and the key architectural differences between **GLiNER (v1)** and **GLiNER2**.
+
+The goal of this document is to help developers and coding agents understand how GLiNER works and what changes may affect the `fast_gliner` inference engine.
+
+---
+
+# What is GLiNER?
+
+GLiNER (Generalist Language Interface for Named Entity Recognition) is a lightweight transformer-based model designed for **zero-shot Named Entity Recognition (NER)**.
+
+Unlike traditional NER systems that require predefined entity types during training, GLiNER allows users to **define entity labels at inference time**.
+
+Instead of generating text like large language models, GLiNER uses a **bidirectional transformer encoder** to score spans against user-provided entity labels.
+
+This allows:
+
+- flexible entity definitions
+- parallel inference
+- fast CPU execution
+
+GLiNER was introduced in:
+
+Zaratiana et al. (2024)  
+"GLiNER: Generalist Model for Named Entity Recognition using Bidirectional Transformer"
+
+---
+
+# GLiNER Architecture (v1)
+
+GLiNER uses a **prompt-based span extraction architecture**.
+
+At inference time the user provides:
+
+- input text
+- entity labels
+
+The model constructs a prompt combining both and performs span classification.
+
+Example prompt format:
+
+<<ENT>> person <<ENT>> organization <<SEP>> input text
+
+The model then predicts which spans correspond to each entity type.
+
+---
+
+# GLiNER v1 Inference Tasks
+
+GLiNER v1 primarily focuses on **Named Entity Recognition**.
+
+Additional capabilities such as relation extraction can be implemented on top of the NER pipeline.
+
+Core characteristics:
+
+- span-based entity detection
+- zero-shot entity types
+- bidirectional transformer encoder
+- efficient CPU inference
+- ONNX export compatibility
+
+---
+
+# GLiNER2 Overview
+
+GLiNER2 extends the original architecture into a **general-purpose information extraction system**.
+
+Instead of focusing only on NER, GLiNER2 unifies several NLP tasks into a single model.
+
+These tasks include:
+
+- Named Entity Recognition
+- Text Classification
+- Structured Data Extraction
+- Relation Extraction
+
+The model still uses a **transformer encoder architecture**, but introduces a **schema-driven interface** to describe extraction tasks.
+
+---
+
+# Schema-Based Extraction
+
+One of the key innovations of GLiNER2 is the use of **schemas**.
+
+Instead of providing a flat list of entity labels, users define a structured schema describing the desired output.
+
+Example schema:
+
+```python
+schema = {
+    "entities": ["person", "organization"],
+    "relations": [
+        {
+            "relation": "founder",
+            "subject": "person",
+            "object": "organization"
+        }
+    ],
+    "classification": {
+        "sentiment": ["positive", "negative", "neutral"]
+    }
+}
+```
+
+The model can process this schema and perform **multiple tasks in a single forward pass**.
+
+---
+
+# Key Improvements in GLiNER2
+
+GLiNER2 introduces several major improvements over GLiNER v1.
+
+## 1. Multi‑Task Information Extraction
+
+GLiNER2 supports multiple tasks simultaneously:
+
+- NER
+- classification
+- relation extraction
+- structured extraction
+
+These tasks are executed **within a single model inference**.
+
+---
+
+## 2. Schema‑Driven Interface
+
+GLiNER2 replaces label lists with **structured schemas** describing the desired output.
+
+Benefits:
+
+- more expressive extraction tasks
+- unified interface across tasks
+- easier integration with downstream systems
+
+---
+
+## 3. Unified Extraction Pipeline
+
+GLiNER2 consolidates multiple NLP tasks into a **single encoder architecture**.
+
+Traditional pipelines often require separate models for:
+
+- NER
+- classification
+- relation extraction
+
+GLiNER2 performs them **in a single forward pass**.
+
+---
+
+## 4. Structured Output
+
+GLiNER2 can output structured JSON-like data instead of simple entity spans.
+
+Example output:
+
+```json
+{
+  "entities": {
+    "person": ["Tim Cook"],
+    "company": ["Apple"]
+  },
+  "sentiment": "positive"
+}
+```
+
+This allows the model to act as a **general information extraction engine**.
+
+---
+
+## 5. CPU‑Optimized Inference
+
+GLiNER2 continues the GLiNER design goal of **fast CPU inference**.
+
+Typical characteristics:
+
+- ~205M parameter base model
+- real-time inference on CPU hardware
+- no dependency on large GPU infrastructure
+
+---
+
+# Comparison: GLiNER vs GLiNER2
+
+| Feature | GLiNER | GLiNER2 |
+|------|------|------|
+| Primary Task | NER | Multi-task extraction |
+| Input Format | label list | schema definition |
+| Output | entity spans | structured results |
+| Tasks | NER | NER + classification + relations + structured extraction |
+| Inference | single-task pipeline | unified multi-task pipeline |
+| Architecture | encoder span model | encoder with task heads |
+
+---
+
+# Implications for fast_gliner
+
+The current `fast_gliner` project implements inference for **GLiNER v1 models** using the Rust engine from `gline-rs`.
+
+Supporting GLiNER2 may require changes in:
+
+gline-rs/src/model/input
+gline-rs/src/model/output
+gline-rs/src/model/pipeline
+
+Potential changes include:
+
+- schema parsing
+- additional output heads
+- new tensor shapes
+- new decoding logic
+
+The Python bindings are expected to require **minimal changes**.
+
+---
+
+# References
+
+## Papers
+
+[1] Urchade Zaratiana, Nadi Tomeh, Pierre Holat, and Thierry Charnois.  
+**GLiNER: Generalist Model for Named Entity Recognition using Bidirectional Transformer.**  
+Proceedings of NAACL 2024.
+
+```bibtex
+@inproceedings{zaratiana-etal-2024-gliner,
+  title = "{GL}i{NER}: Generalist Model for Named Entity Recognition using Bidirectional Transformer",
+  author = "Zaratiana, Urchade and Tomeh, Nadi and Holat, Pierre and Charnois, Thierry",
+  booktitle = "Proceedings of the 2024 Conference of the North American Chapter of the Association for Computational Linguistics",
+  year = "2024",
+  publisher = "Association for Computational Linguistics",
+  url = "https://aclanthology.org/2024.naacl-long.300",
+  doi = "10.18653/v1/2024.naacl-long.300",
+  pages = "5364--5376"
+}
+```
+
+[2] Urchade Zaratiana, Gil Pasternak, Oliver Boyd, George Hurn-Maloney, and Ash Lewis.
+GLiNER2: Schema-Driven Multi-Task Learning for Structured Information Extraction.
+Proceedings of EMNLP 2025 System Demonstrations.
+
+```bibtex
+@inproceedings{zaratiana-etal-2025-gliner2,
+  title = "{GL}i{NER}2: Schema-Driven Multi-Task Learning for Structured Information Extraction",
+  author = "Zaratiana, Urchade and Pasternak, Gil and Boyd, Oliver and Hurn-Maloney, George and Lewis, Ash",
+  booktitle = "Proceedings of the 2025 Conference on Empirical Methods in Natural Language Processing: System Demonstrations",
+  year = "2025",
+  publisher = "Association for Computational Linguistics",
+  url = "https://aclanthology.org/2025.emnlp-demos.10/",
+  pages = "130--140"
+}
+```
+
+## Project Repositories
+
+  - [GLiNER](https://github.com/urchade/GLiNER) (original implementation)
+  - [GLiNER2](https://github.com/fastino-ai/GLiNER2) (next-generation framework)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,92 @@
+# ROADMAP.md
+
+This document describes the future development plan for `fast_gliner`.
+
+---
+
+# Phase 1 (Completed)
+
+Initial release of Python bindings for the Rust inference engine `gline-rs`.
+
+Features delivered:
+
+- Named Entity Recognition (NER) inference
+- Relation extraction
+- CPU execution support
+- CUDA execution support
+- PyPI distribution
+
+The project currently supports **GLiNER v1 models** exported to ONNX.
+
+---
+
+# Phase 2 (Current) — GLiNER2 Support
+
+The next development phase introduces support for **GLiNER2 models**.
+
+GLiNER2 expands the original GLiNER architecture into a **schema-driven multi-task information extraction system**.
+
+Supporting GLiNER2 may require updates to the Rust inference engine.
+
+Background information about GLiNER and GLiNER2 is documented in [`docs/GLINER_OVERVIEW.md`](./docs/GLINER_OVERVIEW.md).
+
+That document also contains references to the official repositories and research papers.
+
+---
+
+## Investigation Tasks
+
+Before implementing support, the following areas must be analyzed:
+
+1. GLiNER2 model architecture
+2. ONNX graph structure
+3. tensor input formats
+4. tensor output formats
+5. tokenization differences
+6. decoding logic for structured outputs
+
+---
+
+## Expected Impact on fast_gliner
+
+Most changes will occur inside the Rust inference engine:
+
+```
+gline-rs/src/model/input
+gline-rs/src/model/output
+gline-rs/src/model/pipeline
+```
+
+
+Possible modifications include:
+
+- schema parsing
+- additional model output heads
+- modified tensor shapes
+- updated span decoding logic
+
+The Python bindings are expected to require **minimal changes**.
+
+---
+
+## Planned Implementation Steps
+
+1. Inspect the GLiNER2 repository
+2. Export a GLiNER2 model to ONNX
+3. Compare ONNX graphs with GLiNER v1 models
+4. Identify differences in input tensors
+5. Identify differences in output tensors
+6. Update the Rust inference pipeline
+7. Validate compatibility with the Python API
+
+---
+
+# Phase 3 (Future)
+
+Possible future improvements for `fast_gliner`:
+
+- dynamic batching
+- streaming inference
+- improved GPU execution
+- multi-model loading
+- improved memory management


### PR DESCRIPTION
Introduce AGENTS.md, ARCHITECTURE.md, and docs/ for development, roadmap, and GLiNER overview. Update README with documentation navigation and contributor guidance.