### PR TITLE
Integrate GLiNER2 across Rust runtime, Python bindings and docs.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,127 +1,111 @@
 # ARCHITECTURE.md
 
-This document describes the internal architecture of **fast_gliner** and its Rust inference engine.
+This document describes the internal architecture of **fast_gliner** and
+its Rust inference engine.
 
-The goal of the project is to provide **fast CPU/GPU inference for GLiNER models** through a Python API while keeping heavy computation inside Rust.
+The goal of the project is to provide **fast CPU/GPU inference for
+GLiNER models** through a Python API while keeping heavy computation
+inside Rust.
 
----
+------------------------------------------------------------------------
 
 # System Overview
 
 The system consists of four major layers:
 
-Python API
-    ↓
-PyO3 bindings
-    ↓
-Rust GLiNER inference engine
-    ↓
-ONNX Runtime
-    ↓
-GLiNER model
+Python API ↓ PyO3 bindings ↓ Rust inference engine (`gline-rs`) ↓ ONNX
+Runtime ↓ GLiNER / GLiNER2 ONNX model
 
-Python exposes a simple API for users, while Rust handles the full inference pipeline and performance‑critical operations.
+Python exposes a simple API for users, while Rust handles the full
+inference pipeline and performance‑critical operations.
 
----
+------------------------------------------------------------------------
 
 # Repository Structure
 
-```
-fast_gliner
-│
-├── AGENTS.md
-├── ARCHITECTURE.md
-│
-├── bindings/python
-│   Python package and PyO3 bindings
-│
-└── gline-rs
-    Rust inference engine
-```
+    fast_gliner
+    ├── ARCHITECTURE.md
+    │
+    ├── bindings/python
+    │   Python package and PyO3 bindings
+    │
+    └── gline-rs
+        Rust inference engine
 
-The repository intentionally vendors the `gline-rs` project instead of using it as an external dependency.
+The repository vendors the `gline-rs` project so the Python bindings and
+Rust inference engine can evolve together.
 
-This allows the Python bindings and Rust inference engine to evolve together.
-
----
+------------------------------------------------------------------------
 
 # Python Layer
 
 Location:
 
-```
-bindings/python/py_src/fast_gliner
-```
+    bindings/python/py_src/fast_gliner
 
-Main class:
+Public runtime classes:
 
-```
-FastGLiNER
-```
+    FastGLiNER
+    FastGLiNER2
 
 Responsibilities:
 
-• model loading  
-• API interface for users  
-• validating inputs  
-• calling Rust extension functions  
-• formatting outputs  
+• model loading (`from_pretrained`)\
+• API interface for users\
+• input validation and normalization\
+• calling Rust extension classes (`PyFastGliNER`, `PyFastGliNER2`)\
+• formatting outputs
 
-The Python layer should remain **thin**.
+The Python layer should remain **thin**. All heavy computation must
+remain inside Rust.
 
-All heavy computation must remain inside Rust.
+------------------------------------------------------------------------
 
----
-
-# Rust Engine
+# Rust Layer
 
 Location:
 
-```
-gline-rs/src
-```
+    gline-rs/src
 
-Main modules:
+Top‑level modules:
 
-```
-model/
-text/
-util/
-```
+    model/
+    text/
+    util/
 
-The Rust crate implements the full GLiNER inference pipeline.
+The Rust crate implements the full GLiNER inference pipeline and runtime
+implementations.
 
----
+------------------------------------------------------------------------
 
-# Pipeline Architecture
+# GLiNER v1 Architecture
+
+GLiNER v1 uses a **prompt‑based architecture** where entity labels are
+embedded into the input text.
 
 Inference is implemented as a **composable processing pipeline**.
 
-Each stage converts data into a new representation until the final entity spans are produced.
-
 High‑level flow:
 
-```
-TextInput
-  ↓
-TokenizedInput
-  ↓
-PromptInput
-  ↓
-EncodedInput
-  ↓
-Tensor preparation
-  ↓
-ONNX Runtime inference
-  ↓
-TensorOutput
-  ↓
-Span decoding
-  ↓
-Greedy filtering
-```
+    TextInput
+      ↓
+    TokenizedInput
+      ↓
+    PromptInput
+      ↓
+    EncodedInput
+      ↓
+    Tensor preparation
+      ↓
+    ONNX Runtime inference
+      ↓
+    TensorOutput
+      ↓
+    Span decoding
+      ↓
+    Greedy filtering
 
----
+------------------------------------------------------------------------
 
 # Input Pipeline
 
@@ -131,30 +115,26 @@ Represents raw input text and entity labels.
 
 ## TokenizedInput
 
-Word tokenization using RegexSplitter.
+Word tokenization using `RegexSplitter`.
 
 ## PromptInput
 
 Constructs GLiNER prompts:
 
-```
-<<ENT>> entity1 <<ENT>> entity2 <<SEP>> text tokens
-```
+    <<ENT>> entity1 <<ENT>> entity2 <<SEP>> text tokens
 
 ## EncodedInput
 
-Subword tokenization via HuggingFace tokenizer.
+Subword tokenization using a HuggingFace tokenizer.
 
-Produces tensors:
+Produces tensors such as:
 
-```
-input_ids  
-attention_mask  
-word_mask  
-text_lengths
-```
+    input_ids
+    attention_mask
+    word_mask
+    text_lengths
 
----
+------------------------------------------------------------------------
 
 # Tensor Preparation
 
@@ -166,10 +146,8 @@ Used for most GLiNER NER models.
 
 Additional tensors:
 
-```
-span_idx  
-span_mask
-```
+    span_idx
+    span_mask
 
 ## Token Mode
 
@@ -177,68 +155,60 @@ Used for multitask GLiNER models.
 
 Works with token-level logits.
 
----
+------------------------------------------------------------------------
 
 # Model Inference
 
 The ONNX model is executed through:
 
-```
-orp::model::Model
-```
+    orp::model::Model
 
 Which wraps **ONNX Runtime**.
 
 Execution providers include:
 
-• CPU  
+• CPU\
 • CUDA
 
----
+------------------------------------------------------------------------
 
 # Output Pipeline
 
 After inference, the model produces:
 
-TensorOutput
+    TensorOutput
 
 This tensor is decoded into entity spans.
 
----
+------------------------------------------------------------------------
 
 # Span Decoding
 
 Expected tensor shape:
 
-```
-(batch_size, num_words, max_width, num_classes)
-```
+    (batch_size, num_words, max_width, num_classes)
 
 Converted into spans containing:
 
-```
-text  
-label  
-probability  
-start_offset  
-end_offset
-```
+    text
+    label
+    probability
+    start_offset
+    end_offset
 
----
+------------------------------------------------------------------------
 
 # Token Decoding
 
-Token mode uses three token logits:
+Token mode uses three logits:
 
-```
-start  
-end  
-inside
-```
+    start
+    end
+    inside
 
 These logits are combined to reconstruct spans.
 
----
+------------------------------------------------------------------------
 
 # Span Filtering
 
@@ -246,13 +216,11 @@ Decoded spans are filtered using **greedy search**.
 
 Filtering rules:
 
-```
-flat_ner  
-dup_label  
-multi_label
-```
+    flat_ner
+    dup_label
+    multi_label
 
----
+------------------------------------------------------------------------
 
 # Relation Extraction
 
@@ -260,96 +228,178 @@ Relation extraction builds on top of NER results.
 
 Pipeline:
 
-```
-NER spans
-   ↓
-relation prompts
-   ↓
-token pipeline
-   ↓
-relation decoding
+    NER spans
+       ↓
+    relation prompts
+       ↓
+    token pipeline
+       ↓
+    relation decoding
 
 Relations are validated against a schema.
-```
 
----
+------------------------------------------------------------------------
+
+# GLiNER2 Runtime
+
+Location:
+
+    gline-rs/src/model/gliner2/
+
+GLiNER2 is implemented as a **separate runtime family** from the
+original GLiNER implementation.
+
+Key differences:
+
+• does **not use prompt-based label encoding**\
+• does **not rely on `gliner_config.json`**\
+• builds schema representations directly in tokenizer space
+
+------------------------------------------------------------------------
+
+## GLiNER2 Loader
+
+    GLiNER2::from_dir(model_dir, params, runtime_params)
+
+Loader flow:
+
+    model_dir
+       ↓
+    resolve tokenizer.json
+    resolve ONNX model path
+       ↓
+    initialize GLiNER2Tokenizer
+       ↓
+    resolve special tokens
+       ↓
+    initialize ONNX runtime
+
+Required files:
+
+    tokenizer.json
+    model.onnx
+
+------------------------------------------------------------------------
+
+## Special Token Resolution
+
+GLiNER2 resolves runtime control tokens directly from the tokenizer
+vocabulary.
+
+Required tokens:
+
+    [P]
+    [E]
+    [SEP_TEXT]
+
+These are resolved via:
+
+    tokenizer.token_to_id(...)
+
+If any token is missing, runtime initialization fails.
+
+------------------------------------------------------------------------
+
+## GLiNER2 Inference Pipeline
+
+High‑level flow:
+
+    TextInput
+       ↓
+    schema prefix construction
+       ↓
+    tokenizer encoding
+       ↓
+    tensor preparation
+       ↓
+    ONNX inference
+       ↓
+    span decoding
+       ↓
+    greedy filtering
+
+Example tensors:
+
+    input_ids
+    attention_mask
+    text_positions
+    schema_positions
+    span_idx
+
+------------------------------------------------------------------------
 
 # Text Module
 
-The `text` module provides core structures:
+The `text` module provides shared primitives:
 
-```
-Token  
-Span  
-Tokenizer  
-Splitter  
-Prompt
-```
+    Token
+    Span
+    Tokenizer
+    Splitter
+    Prompt
 
 These maintain alignment between tokens and original text offsets.
 
----
+------------------------------------------------------------------------
 
 # Utility Module
 
-The `util` module provides shared helpers such as:
+The `util` module provides shared helpers:
 
-• error handling  
-• math utilities  
-• shared result types  
+• error handling\
+• math utilities\
+• shared result types
 
----
+------------------------------------------------------------------------
 
 # Execution Flow
 
-Typical inference call:
+Typical GLiNER v1 call:
 
-```
-Python FastGLiNER
-      ↓
-Rust PyFastGliNER
-      ↓
-GLiNER pipeline
-      ↓
-ONNX Runtime
-      ↓
-decoded spans
-      ↓
-Python result formatting
-```
+    Python FastGLiNER
+          ↓
+    Rust PyFastGliNER
+          ↓
+    GLiNER pipeline
+          ↓
+    ONNX Runtime
+          ↓
+    decoded spans
+          ↓
+    Python result formatting
 
----
+Typical GLiNER2 call:
+
+    Python FastGLiNER2
+          ↓
+    Rust PyFastGliNER2
+          ↓
+    GLiNER2 runtime
+          ↓
+    ONNX Runtime
+          ↓
+    decoded spans
+          ↓
+    Python result formatting
+
+------------------------------------------------------------------------
 
 # Performance Goals
 
 The engine prioritizes:
 
-• minimal allocations  
-• safe Rust code  
-• efficient tensor operations  
-• batch processing  
+• minimal allocations\
+• efficient tensor operations\
+• safe Rust code\
+• CPU and GPU inference
 
----
+------------------------------------------------------------------------
 
 # Extension Points
 
 Future features should primarily modify:
 
-```
-gline-rs/src/model/input
-gline-rs/src/model/output
-gline-rs/src/model/pipeline
-```
-
-These areas define model architecture behavior.
-
----
-
-# Future Development
-
-Planned improvements include:
-
-• GLiNER2 model support  
-• improved CUDA execution  
-• additional decoding strategies  
-• improved batching support
+    gline-rs/src/model/input
+    gline-rs/src/model/output
+    gline-rs/src/model/pipeline
+    gline-rs/src/model/gliner2

--- a/README.md
+++ b/README.md
@@ -55,8 +55,23 @@ Output:
         'score': 0.9012733697891235,
         'start': 5,
         'end': 15
-    }
+}
 ]
+```
+
+## GLiNER2 NER Example
+
+```python
+from fast_gliner import FastGLiNER2
+
+model = FastGLiNER2.from_pretrained(
+    "lion-ai/gliner2-multi-v1-onnx"
+)
+
+model.predict_entities(
+    "I am James Bond",
+    ["person"]
+)
 ```
 
 ### Relation Extraction

--- a/bindings/python/py_src/fast_gliner/__init__.py
+++ b/bindings/python/py_src/fast_gliner/__init__.py
@@ -1,41 +1,22 @@
 from pathlib import Path
 from typing import List, Literal, Optional, Union
+from abc import ABC
 
 from huggingface_hub import snapshot_download
 
-from .fast_gliner import PyFastGliNER, PyRelationSchemaEntry
+from .fast_gliner import PyFastGliNER, PyFastGliNER2, PyRelationSchemaEntry
 
 
-class FastGLiNER:
+class _FastGLiNERBase(ABC):
     """
-    This is a wrapper class for PyFastGliNER.
+    Shared functionality for FastGLiNER runtimes.
 
-    It is used to initialize the PyFastGliNER class and call its methods.
-
-    ```python
-    from fast_gliner import FastGLiNER
-
-    model = FastGLiNER.from_pretrained(
-        model_id="juampahc/gliner_multi-v2.1-onnx",
-        onnx_path="model.onnx"
-    )
-
-    model.predict_entities("I am James Bond", ["person"])
-    ```
-
-    Output:
-    ```
-    [
-        {
-            'text': 'James Bond',
-            'label': 'person',
-            'score': 0.9012733697891235,
-            'start': 5,
-            'end': 15
-        }
-    ]
-    ```
+    This class implements common functionality for loading models,
+    normalizing inputs, and running inference. Concrete runtimes
+    provide the backend implementation via `_backend`.
     """
+
+    _backend = None
 
     def __init__(
         self,
@@ -43,74 +24,59 @@ class FastGLiNER:
         onnx_path: Optional[str] = "onnx/model.onnx",
         execution_provider: Optional[Literal["cpu", "cuda"]] = None,
     ):
-        self.model = PyFastGliNER(model_path, onnx_path, execution_provider)
+        self.model = self._backend(model_path, onnx_path, execution_provider)
+
+    @staticmethod
+    def _normalize_input(input_text):
+        """
+        Normalize user input to a list of texts.
+
+        Returns
+        -------
+        Tuple[List[str], bool]
+            Normalized texts and whether the original input was a single string.
+        """
+        if isinstance(input_text, str):
+            return [input_text], True
+        return input_text, False
 
     def predict_entities(
         self, input_text: Union[str, List[str]], labels: List[str]
     ) -> Union[List[dict], List[List[dict]]]:
-        """Predict entities in the given texts.
-
-        Args:
-            input_text (str, List[str]): A list of texts to predict entities for.
-
-        Returns:
-            List[List[dict]]: A list of lists of dictionaries containing the predicted entities.
         """
-        single_input = False
+        Predict entities in the given text(s).
 
-        if isinstance(input_text, str):
-            input_text = [input_text]
-            single_input = True
+        Parameters
+        ----------
+        input_text : str or List[str]
+            Input text or batch of texts.
+        labels : List[str]
+            Entity labels to detect.
 
-        results = self.model.predict_entities(input_text, labels)
+        Returns
+        -------
+        List[dict] or List[List[dict]]
+            Predicted entities.
+        """
 
-        if single_input:
-            return results[0]
-        return results
-    
+        texts, single = self._normalize_input(input_text)
+
+        results = self.model.predict_entities(texts, labels)
+
+        return results[0] if single else results
+
     def extract_relations(
         self,
         input_text: Union[str, List[str]],
         labels: List[str],
         schema: List[dict],
-    ) -> Union[List[dict], List[List[dict]]]:
-        """Extract relations between entities based on a user-defined schema.
-
-        Args:
-            input_text (str or List[str]): Input text or batch of texts.
-            labels (List[str]): List of entity labels to recognize.
-            schema (List[dict]): List of relation definitions, each dict should contain:
-                - relation (str): name of the relation
-                - subject_labels (List[str]): list of valid subject entity labels
-                - object_labels (List[str]): list of valid object entity labels
-
-        Returns:
-            List[dict] or List[List[dict]]: A list of relation dicts with fields:
-                - relation: str
-                - subject: dict (text, start, end, label)
-                - object: dict (text, start, end, label)
-                - score: float
+    ):
         """
-        single_input = False
+        Relation extraction is runtime-dependent.
 
-        if isinstance(input_text, str):
-            input_text = [input_text]
-            single_input = True
-
-        schema_entries = [
-            PyRelationSchemaEntry(
-                relation=entry["relation"],
-                subject_labels=entry["subject_labels"],
-                object_labels=entry["object_labels"],
-            )
-            for entry in schema
-        ]
-
-        results = self.model.extract_relations(input_text, labels, schema_entries)
-
-        if single_input:
-            return results[0]
-        return results
+        This method must be implemented by runtimes that support relation extraction.
+        """
+        raise NotImplementedError("Relation extraction is not supported for this GLiNER runtime.")
 
     @classmethod
     def from_pretrained(
@@ -119,31 +85,30 @@ class FastGLiNER:
         onnx_path: Optional[str] = "onnx/model.onnx",
         execution_provider: Optional[Literal["cpu", "cuda"]] = None,
         **kwargs,
-    ) -> "FastGLiNER":
-        """Load a pretrained model from the Hugging Face Model Hub.
-
-        Args:
-            model_id (str): The name of the model on the Hugging Face Model Hub or a local path.
-            onnx_path (str, optional): The path to the onnx model in the model directory. Defaults to "onnx/model.onnx".
-            execution_provider (str, optional): The ONNXRuntime provider (e.g. "cuda" or "cpu"). Default to None.
-            **kwargs: extra args for the `huggingface_hub.snapshot_download` method.
-
-        Returns:
-            FastGLiNER: An instance of the FastGLiNER class.
-
-        Raises:
-            [`~utils.RepositoryNotFoundError`]
-                If the repository to download from cannot be found. This may be because it doesn't exist,
-                or because it is set to `private` and you do not have access.
-            [`~utils.RevisionNotFoundError`]
-                If the revision to download from cannot be found.
-            [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-                If `token=True` and the token cannot be found.
-            [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
-                ETag cannot be determined.
-            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-                if some parameter value is invalid.
+    ):
         """
+        Load a pretrained model from the Hugging Face Model Hub or a local directory.
+
+        Parameters
+        ----------
+        model_id : str
+            Hugging Face repository ID or local directory path.
+        onnx_path : str, optional
+            Path to the ONNX model inside the model directory.
+        execution_provider : {"cpu", "cuda"}, optional
+            ONNX Runtime execution provider.
+
+        Returns
+        -------
+        FastGLiNER or FastGLiNER2
+            Loaded model instance.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the ONNX model cannot be located.
+        """
+
         model_dir = Path(model_id)
 
         if not model_dir.exists():
@@ -155,27 +120,136 @@ class FastGLiNER:
                 )
             )
 
-            if not (model_dir / onnx_path).exists():
-                snapshot_download(repo_id=model_id, allow_patterns=["*.onnx"], **kwargs)
-                onnx_files = sorted(model_dir.rglob("*.onnx"))
-                if len(onnx_files) == 1:
-                    onnx_path = onnx_files[0].relative_to(model_dir).as_posix()
-        else:
-            model_file = model_dir / onnx_path
+        if not (model_dir / onnx_path).exists():
+            onnx_files = sorted(model_dir.rglob("*.onnx"))
 
-            if not model_file.exists():
-                raise FileNotFoundError(f"The ONNX model can't be loaded from {model_file}.")
+            if len(onnx_files) == 1:
+                onnx_path = onnx_files[0].relative_to(model_dir).as_posix()
+            else:
+                raise FileNotFoundError(f"Could not resolve ONNX model inside {model_dir}")
 
-            config_file = model_dir / "gliner_config.json"
+        return cls(str(model_dir.resolve()), onnx_path, execution_provider)
 
-            if not config_file.exists():
-                raise FileNotFoundError(f"The config file can't be loaded from {config_file}.")
 
-            model_dir = model_dir.resolve()
+class FastGLiNER(_FastGLiNERBase):
+    """
+    Python wrapper for the GLiNER runtime.
 
-        return cls(str(model_dir), onnx_path, execution_provider=execution_provider)
+    Example
+    -------
+    ```python
+    from fast_gliner import FastGLiNER
+
+    model = FastGLiNER.from_pretrained(
+        model_id="juampahc/gliner_multi-v2.1-onnx"
+    )
+
+    model.predict_entities("I am James Bond", ["person"])
+    ```
+
+    Output
+    ------
+    ```python
+    [
+        {
+            "text": "James Bond",
+            "label": "person",
+            "score": 0.90,
+            "start": 5,
+            "end": 15
+        }
+    ]
+    ```
+    """
+
+    _backend = PyFastGliNER
+
+    def extract_relations(
+        self,
+        input_text: Union[str, List[str]],
+        labels: List[str],
+        schema: List[dict],
+    ) -> Union[List[dict], List[List[dict]]]:
+        """
+        Extract relations between entities based on a user-defined schema.
+
+        Parameters
+        ----------
+        input_text : str or List[str]
+            Input text or batch of texts.
+        labels : List[str]
+            Entity labels to detect.
+        schema : List[dict]
+            Relation definitions with:
+            - relation
+            - subject_labels
+            - object_labels
+
+        Returns
+        -------
+        List[dict] or List[List[dict]]
+            Extracted relations.
+        """
+
+        texts, single = self._normalize_input(input_text)
+
+        schema_entries = [
+            PyRelationSchemaEntry(
+                relation=entry["relation"],
+                subject_labels=entry["subject_labels"],
+                object_labels=entry["object_labels"],
+            )
+            for entry in schema
+        ]
+
+        results = self.model.extract_relations(texts, labels, schema_entries)
+
+        return results[0] if single else results
+
+
+class FastGLiNER2(_FastGLiNERBase):
+    """
+    Python wrapper around the GLiNER2 runtime.
+
+    GLiNER2 currently supports **NER inference only**.
+
+    Example
+    -------
+    ```python
+    from fast_gliner import FastGLiNER2
+
+    model = FastGLiNER2.from_pretrained(
+        model_id="lion-ai/gliner2-multi-v1-onnx"
+    )
+
+    model.predict_entities("I am James Bond", ["person"])
+    ```
+    """
+
+    _backend = PyFastGliNER2
+
+    def predict_entities(
+        self, input_text: Union[str, List[str]], labels: List[str]
+    ) -> Union[List[dict], List[List[dict]]]:
+        """
+        Run NER inference using GLiNER2.
+
+        Note
+        ----
+        GLiNER2 currently does **not support batched inference**.
+        """
+
+        if isinstance(input_text, list) and len(input_text) > 1:
+            raise ValueError(
+                "GLiNER2 currently does not support batched inference. Please pass a single input string."
+            )
+
+        return super().predict_entities(input_text, labels)
+
+    def extract_relations(self, *args, **kwargs):
+        raise NotImplementedError("GLiNER2 relation extraction is not implemented yet.")
 
 
 __version__ = "0.1.12"
 
-__all__ = ["FastGLiNER"]
+__all__ = ["FastGLiNER", "FastGLiNER2"]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3,6 +3,7 @@ use pyo3::types::{PyDict, PyList};
 use pyo3::{Py, Python};
 use std::path::Path;
 
+use gliner::model::gliner2::GLiNER2;
 use gliner::model::input::relation::schema::RelationSchema;
 use gliner::model::output::decoded::SpanOutput;
 use gliner::model::pipeline::{relation::RelationPipeline, token::TokenPipeline};
@@ -24,6 +25,11 @@ use orp::pipeline::*;
 pub struct PyFastGliNER {
     model: Box<dyn Inferencer + Send + Sync>,
     tokenizer_path: String,
+}
+
+#[pyclass]
+pub struct PyFastGliNER2 {
+    model: GLiNER2,
 }
 
 trait Inferencer: Send + Sync {
@@ -73,30 +79,7 @@ impl PyFastGliNER {
     ) -> PyResult<Self> {
         let base = Path::new(&model_dir);
         let tokenizer_path = base.join("tokenizer.json");
-
-        let providers: Vec<ExecutionProviderDispatch> = match execution_provider.as_deref() {
-            Some("cuda") => {
-                #[cfg(feature = "cuda")]
-                {
-                    vec![CUDAExecutionProvider::default().build()]
-                }
-                #[cfg(not(feature = "cuda"))]
-                {
-                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
-                        "CUDA execution provider requested but 'cuda' feature is not enabled",
-                    ));
-                }
-            }
-            Some("cpu") => vec![CPUExecutionProvider::default().build()],
-            None => vec![],
-            Some(other) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "Unsupported execution provider: '{}'. Use 'cpu' or 'cuda'.",
-                    other
-                )))
-            }
-        };
-
+        let providers = execution_providers_from_arg(execution_provider)?;
         let runtime_params = RuntimeParameters::default().with_execution_providers(providers);
 
         let model = match filename.as_deref() {
@@ -136,25 +119,7 @@ impl PyFastGliNER {
             .allow_threads(|| self.model.inference(input))
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
 
-        let results = PyList::empty_bound(py);
-
-        for spans in output.spans {
-            let py_spans = PyList::empty_bound(py);
-            for span in spans {
-                let span_dict = PyDict::new_bound(py);
-                span_dict.set_item("text", span.text())?;
-                span_dict.set_item("label", span.class())?;
-                span_dict.set_item("score", span.probability())?;
-
-                let (start, end) = span.offsets();
-                span_dict.set_item("start", start)?;
-                span_dict.set_item("end", end)?;
-                py_spans.append(span_dict)?;
-            }
-            results.append(py_spans)?;
-        }
-
-        Ok(results.into())
+        span_output_to_py(py, output)
     }
 
     fn extract_relations(
@@ -235,9 +200,114 @@ impl PyFastGliNER {
     }
 }
 
+#[pymethods]
+impl PyFastGliNER2 {
+    #[new]
+    fn new(
+        model_dir: String,
+        filename: Option<String>,
+        execution_provider: Option<String>,
+    ) -> PyResult<Self> {
+        let providers = execution_providers_from_arg(execution_provider)?;
+        let runtime_params = RuntimeParameters::default().with_execution_providers(providers);
+
+        if let Some(path) = filename.as_deref() {
+            if path != "onnx/model.onnx" && path != "model.onnx" {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "PyFastGliNER2 loads models via GLiNER2::from_dir and currently supports only the default ONNX layout",
+                ));
+            }
+        }
+
+        let model = GLiNER2::from_dir(&model_dir, Parameters::default(), runtime_params)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
+
+        Ok(Self { model })
+    }
+
+    fn predict_entities(
+        &self,
+        py: Python<'_>,
+        texts: Vec<String>,
+        labels: Vec<String>,
+    ) -> PyResult<Py<PyAny>> {
+        let texts_ref: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        let labels_ref: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+
+        let input = TextInput::from_str(&texts_ref, &labels_ref)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{:?}", e)))?;
+
+        let output = py
+            .allow_threads(|| self.model.inference(input))
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
+
+        span_output_to_py(py, output)
+    }
+
+    fn extract_relations(
+        &self,
+        _py: Python<'_>,
+        _texts: Vec<String>,
+        _entity_labels: Vec<String>,
+        _relation_schema_entries: Vec<PyRelationSchemaEntry>,
+    ) -> PyResult<Py<PyAny>> {
+        Err(pyo3::exceptions::PyNotImplementedError::new_err(
+            "GLiNER2 Python bindings currently expose NER only; relation extraction is not wired for GLiNER2 yet",
+        ))
+    }
+}
+
 #[pymodule]
 fn fast_gliner(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyFastGliNER>()?;
+    m.add_class::<PyFastGliNER2>()?;
     m.add_class::<PyRelationSchemaEntry>()?;
     Ok(())
+}
+
+fn execution_providers_from_arg(
+    execution_provider: Option<String>,
+) -> PyResult<Vec<ExecutionProviderDispatch>> {
+    match execution_provider.as_deref() {
+        Some("cuda") => {
+            #[cfg(feature = "cuda")]
+            {
+                Ok(vec![CUDAExecutionProvider::default().build()])
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "CUDA execution provider requested but 'cuda' feature is not enabled",
+                ))
+            }
+        }
+        Some("cpu") => Ok(vec![CPUExecutionProvider::default().build()]),
+        None => Ok(vec![]),
+        Some(other) => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Unsupported execution provider: '{}'. Use 'cpu' or 'cuda'.",
+            other
+        ))),
+    }
+}
+
+fn span_output_to_py(py: Python<'_>, output: SpanOutput) -> PyResult<Py<PyAny>> {
+    let results = PyList::empty_bound(py);
+
+    for spans in output.spans {
+        let py_spans = PyList::empty_bound(py);
+        for span in spans {
+            let span_dict = PyDict::new_bound(py);
+            span_dict.set_item("text", span.text())?;
+            span_dict.set_item("label", span.class())?;
+            span_dict.set_item("score", span.probability())?;
+
+            let (start, end) = span.offsets();
+            span_dict.set_item("start", start)?;
+            span_dict.set_item("end", end)?;
+            py_spans.append(span_dict)?;
+        }
+        results.append(py_spans)?;
+    }
+
+    Ok(results.into())
 }

--- a/gline-rs/examples/gliner2_ner.rs
+++ b/gline-rs/examples/gliner2_ner.rs
@@ -1,0 +1,49 @@
+use gliner::model::{gliner2::GLiNER2, input::text::TextInput, params::Parameters};
+use gliner::util::result::Result;
+use orp::params::RuntimeParameters;
+
+/// Example: load a GLiNER2 model and run NER inference
+fn main() -> Result<()> {
+    let model_dir = std::env::args()
+        .nth(1)
+        .ok_or("Usage: cargo run --example gliner2_ner -- <model_dir>")?;
+
+    println!("Loading model from: {}", model_dir);
+
+    let model = GLiNER2::from_dir(
+        model_dir,
+        Parameters::default(),
+        RuntimeParameters::default(),
+    )?;
+
+    let input = TextInput::from_str(
+        &[
+            "I am James Bond",
+            "This is James and I live in Chelsea, London.",
+            "My name is Bond, James Bond.",
+            "I like to drive my Aston Martin.",
+            "The villain in the movie is Auric Goldfinger.",
+        ],
+        &["person", "location", "vehicle"],
+    )?;
+
+    println!("Running inference...");
+
+    let output = model.inference(input)?;
+
+    println!("Results:");
+
+    for spans in output.spans {
+        for span in spans {
+            println!(
+                "{:3} | {:16} | {:10} | {:.1}%",
+                span.sequence(),
+                span.text(),
+                span.class(),
+                span.probability() * 100.0
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/gline-rs/models/.gitignore
+++ b/gline-rs/models/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!Readme.md

--- a/gline-rs/src/model/gliner2/decoder.rs
+++ b/gline-rs/src/model/gliner2/decoder.rs
@@ -1,0 +1,140 @@
+use composable::Composable;
+use ort::session::SessionOutputs;
+
+use crate::model::output::decoded::{greedy::GreedySearch, sort::SpanSort, SpanOutput};
+use crate::text::{span::Span, token::Token};
+use crate::util::result::Result;
+
+const OUTPUT_SPAN_SCORES: &str = "span_scores";
+
+pub struct SequenceContext {
+    pub sequence_index: usize,
+    pub text: String,
+    pub tokens: Vec<Token>,
+    pub entities: Vec<String>,
+}
+
+pub struct OutputsToSpans {
+    threshold: f32,
+    max_width: usize,
+    flat_ner: bool,
+    dup_label: bool,
+    multi_label: bool,
+}
+
+impl OutputsToSpans {
+    pub fn new(
+        threshold: f32,
+        max_width: usize,
+        flat_ner: bool,
+        dup_label: bool,
+        multi_label: bool,
+    ) -> Self {
+        Self {
+            threshold,
+            max_width,
+            flat_ner,
+            dup_label,
+            multi_label,
+        }
+    }
+
+    pub fn outputs() -> [&'static str; 1] {
+        [OUTPUT_SPAN_SCORES]
+    }
+
+    fn decode(
+        &self,
+        outputs: SessionOutputs<'_, '_>,
+        context: SequenceContext,
+    ) -> Result<SpanOutput> {
+        let scores = outputs
+            .get(OUTPUT_SPAN_SCORES)
+            .ok_or("span_scores not found in model output")?;
+        let scores = scores.try_extract_tensor::<f32>()?;
+        let shape = scores.shape();
+
+        if shape.len() != 4 {
+            return Err("unexpected span_scores rank".into());
+        }
+        if shape[0] != 1 {
+            return Err("GLiNER2 runtime expects a batch size of 1 per ONNX invocation".into());
+        }
+        if shape[1] != context.entities.len() {
+            return Err("unexpected number of labels in span_scores".into());
+        }
+        if shape[2] != context.tokens.len() {
+            return Err("unexpected number of words in span_scores".into());
+        }
+
+        let mut spans = Vec::new();
+        let width_limit = std::cmp::min(shape[3], self.max_width);
+
+        for label_index in 0..shape[1] {
+            for start_word in 0..shape[2] {
+                for width in 0..width_limit {
+                    let end_word = start_word + width;
+                    if end_word >= context.tokens.len() {
+                        continue;
+                    }
+
+                    let score = scores[[0, label_index, start_word, width]];
+                    if score < self.threshold {
+                        continue;
+                    }
+
+                    spans.push(make_span(
+                        &context,
+                        start_word,
+                        end_word,
+                        label_index,
+                        score,
+                    )?);
+                }
+            }
+        }
+
+        let output = SpanOutput::new(vec![context.text], context.entities, vec![spans]);
+        let output = SpanSort::default().apply(output)?;
+        GreedySearch::new(self.flat_ner, self.dup_label, self.multi_label).apply(output)
+    }
+}
+
+impl Composable<(SessionOutputs<'_, '_>, SequenceContext), SpanOutput> for OutputsToSpans {
+    fn apply(&self, input: (SessionOutputs<'_, '_>, SequenceContext)) -> Result<SpanOutput> {
+        self.decode(input.0, input.1)
+    }
+}
+
+fn make_span(
+    context: &SequenceContext,
+    start_word: usize,
+    end_word: usize,
+    label_index: usize,
+    score: f32,
+) -> Result<Span> {
+    let start = context
+        .tokens
+        .get(start_word)
+        .ok_or("invalid start word index during GLiNER2 decoding")?
+        .start();
+    let end = context
+        .tokens
+        .get(end_word)
+        .ok_or("invalid end word index during GLiNER2 decoding")?
+        .end();
+    let class = context
+        .entities
+        .get(label_index)
+        .ok_or("invalid label index during GLiNER2 decoding")?
+        .to_string();
+
+    Ok(Span::new(
+        context.sequence_index,
+        start,
+        end,
+        context.text[start..end].to_string(),
+        class,
+        score,
+    ))
+}

--- a/gline-rs/src/model/gliner2/mod.rs
+++ b/gline-rs/src/model/gliner2/mod.rs
@@ -1,0 +1,7 @@
+pub mod decoder;
+pub mod model;
+pub mod schema;
+pub mod spans;
+pub mod tokenizer;
+
+pub use model::GLiNER2;

--- a/gline-rs/src/model/gliner2/model.rs
+++ b/gline-rs/src/model/gliner2/model.rs
@@ -1,0 +1,266 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use composable::Composable;
+use orp::model::Model;
+use orp::params::RuntimeParameters;
+use orp::pipeline::Pipeline;
+use ort::session::SessionInputs;
+
+use crate::model::input::text::TextInput;
+use crate::model::output::decoded::SpanOutput;
+use crate::model::params::Parameters;
+use crate::text::splitter::{RegexSplitter, Splitter};
+use crate::util::result::Result;
+
+use super::decoder::{OutputsToSpans, SequenceContext};
+use super::schema::SchemaPrefix;
+use super::spans::build_span_idx;
+use super::tokenizer::GLiNER2Tokenizer;
+
+const INPUT_IDS: &str = "input_ids";
+const ATTENTION_MASK: &str = "attention_mask";
+const TEXT_POSITIONS: &str = "text_positions";
+const SCHEMA_POSITIONS: &str = "schema_positions";
+const SPAN_IDX: &str = "span_idx";
+const GLINER2_MAX_WIDTH: usize = 8;
+
+pub struct GLiNER2 {
+    params: Parameters,
+    model: Model,
+    pipeline: GLiNER2Pipeline,
+}
+
+impl GLiNER2 {
+    pub fn from_dir<P: AsRef<Path>>(
+        model_dir: P,
+        parameters: Parameters,
+        runtime_parameters: RuntimeParameters,
+    ) -> Result<Self> {
+        let model_dir = model_dir.as_ref();
+        let tokenizer_path = model_dir.join("tokenizer.json");
+        let onnx_model_path = resolve_onnx_path(model_dir);
+
+        validate_required_file("tokenizer", &tokenizer_path)?;
+        validate_required_file("ONNX model", &onnx_model_path)?;
+
+        let tokenizer = GLiNER2Tokenizer::from_file(&tokenizer_path)?;
+        let special_tokens = resolve_special_tokens(&tokenizer)?;
+        // GLiNER2 models currently use a fixed span width baked into the ONNX graph.
+        let parameters = parameters.with_max_width(GLINER2_MAX_WIDTH);
+
+        Ok(Self {
+            params: parameters,
+            model: Model::new(onnx_model_path, runtime_parameters)?,
+            pipeline: GLiNER2Pipeline::new(tokenizer, special_tokens),
+        })
+    }
+
+    pub fn get_inner_model(&self) -> &Model {
+        &self.model
+    }
+
+    pub fn inference(&self, input: TextInput) -> Result<SpanOutput> {
+        let TextInput { texts, entities } = input;
+        let mut spans = Vec::with_capacity(texts.len());
+
+        for (sequence_index, text) in texts.iter().enumerate() {
+            if text.trim().is_empty() {
+                spans.push(Vec::new());
+                continue;
+            }
+
+            let output = self.model.inference(
+                SequenceInput {
+                    sequence_index,
+                    text: text.clone(),
+                    entities: entities.clone(),
+                },
+                &self.pipeline,
+                &self.params,
+            )?;
+
+            spans.push(output.spans.into_iter().next().unwrap_or_default());
+        }
+
+        Ok(SpanOutput::new(texts, entities, spans))
+    }
+}
+
+#[derive(Clone)]
+pub struct SpecialTokens {
+    pub prompt: String,
+    pub entity: String,
+    pub sep_text: String,
+    pub ids: HashMap<String, i64>,
+}
+
+struct SequenceInput {
+    sequence_index: usize,
+    text: String,
+    entities: Vec<String>,
+}
+
+struct GLiNER2Pipeline {
+    tokenizer: GLiNER2Tokenizer,
+    special_tokens: SpecialTokens,
+    expected_inputs: HashSet<&'static str>,
+    expected_outputs: HashSet<&'static str>,
+}
+
+impl GLiNER2Pipeline {
+    fn new(tokenizer: GLiNER2Tokenizer, special_tokens: SpecialTokens) -> Self {
+        Self {
+            tokenizer,
+            special_tokens,
+            expected_inputs: [
+                INPUT_IDS,
+                ATTENTION_MASK,
+                TEXT_POSITIONS,
+                SCHEMA_POSITIONS,
+                SPAN_IDX,
+            ]
+            .into_iter()
+            .collect(),
+            expected_outputs: OutputsToSpans::outputs().into_iter().collect(),
+        }
+    }
+}
+
+impl<'a> Pipeline<'a> for GLiNER2Pipeline {
+    type Input = SequenceInput;
+    type Output = SpanOutput;
+    type Context = SequenceContext;
+    type Parameters = Parameters;
+
+    fn pre_processor(
+        &self,
+        params: &Self::Parameters,
+    ) -> impl orp::pipeline::PreProcessor<'a, Self::Input, Self::Context> {
+        SequenceToTensors {
+            splitter: RegexSplitter::default(),
+            tokenizer: self.tokenizer.clone(),
+            special_tokens: self.special_tokens.clone(),
+            max_width: params.max_width,
+        }
+    }
+
+    fn post_processor(
+        &self,
+        params: &Self::Parameters,
+    ) -> impl orp::pipeline::PostProcessor<'a, Self::Output, Self::Context> {
+        OutputsToSpans::new(
+            params.threshold,
+            params.max_width,
+            params.flat_ner,
+            params.dup_label,
+            params.multi_label,
+        )
+    }
+
+    fn expected_inputs(&self) -> Option<&HashSet<&str>> {
+        Some(&self.expected_inputs)
+    }
+
+    fn expected_outputs(&self) -> Option<&HashSet<&str>> {
+        Some(&self.expected_outputs)
+    }
+}
+
+struct SequenceToTensors {
+    splitter: RegexSplitter,
+    tokenizer: GLiNER2Tokenizer,
+    special_tokens: SpecialTokens,
+    max_width: usize,
+}
+
+impl<'a> Composable<SequenceInput, (SessionInputs<'a, 'a>, SequenceContext)> for SequenceToTensors {
+    fn apply(&self, input: SequenceInput) -> Result<(SessionInputs<'a, 'a>, SequenceContext)> {
+        let tokens = self.splitter.split(&input.text, None)?;
+        if tokens.is_empty() {
+            return Err("invalid input: text contains no tokenizable words".into());
+        }
+
+        let schema =
+            SchemaPrefix::build_ner(&input.entities, &self.special_tokens, &self.splitter)?;
+        let text_piece_offset = schema.pieces.len();
+
+        let mut pieces = schema.pieces;
+        pieces.extend(tokens.iter().map(|token| token.text().to_string()));
+
+        let encoded = self.tokenizer.encode_pieces(&pieces)?;
+        let text_positions = encoded
+            .first_piece_positions
+            .iter()
+            .skip(text_piece_offset)
+            .map(|position| *position as i64)
+            .collect::<Vec<_>>();
+        let schema_positions = schema
+            .schema_piece_indices
+            .iter()
+            .map(|piece_index| encoded.first_piece_positions[*piece_index] as i64)
+            .collect::<Vec<_>>();
+        let span_idx = build_span_idx(tokens.len(), self.max_width);
+
+        let input_ids =
+            ndarray::Array2::from_shape_vec((1, encoded.input_ids.len()), encoded.input_ids)?;
+        let attention_mask = ndarray::Array2::from_shape_vec(
+            (1, encoded.attention_mask.len()),
+            encoded.attention_mask,
+        )?;
+        let text_positions = ndarray::Array1::from_vec(text_positions);
+        let schema_positions = ndarray::Array1::from_vec(schema_positions);
+
+        let session_inputs = ort::inputs! {
+            INPUT_IDS => input_ids,
+            ATTENTION_MASK => attention_mask,
+            TEXT_POSITIONS => text_positions,
+            SCHEMA_POSITIONS => schema_positions,
+            SPAN_IDX => span_idx,
+        }?;
+
+        Ok((
+            session_inputs.into(),
+            SequenceContext {
+                sequence_index: input.sequence_index,
+                text: input.text,
+                tokens,
+                entities: input.entities,
+            },
+        ))
+    }
+}
+
+fn resolve_special_tokens(tokenizer: &GLiNER2Tokenizer) -> Result<SpecialTokens> {
+    let mut ids = HashMap::new();
+    for token in ["[P]", "[E]", "[SEP_TEXT]"] {
+        let token_id = tokenizer.token_to_id(token).ok_or_else(|| {
+            format!("required GLiNER2 special token `{token}` not found in tokenizer.json")
+        })?;
+        ids.insert(token.to_string(), token_id);
+    }
+
+    Ok(SpecialTokens {
+        prompt: "[P]".to_string(),
+        entity: "[E]".to_string(),
+        sep_text: "[SEP_TEXT]".to_string(),
+        ids,
+    })
+}
+
+fn resolve_onnx_path(model_dir: &Path) -> PathBuf {
+    let nested = model_dir.join("onnx/model.onnx");
+    if nested.is_file() {
+        nested
+    } else {
+        model_dir.join("model.onnx")
+    }
+}
+
+fn validate_required_file(component: &str, path: &Path) -> Result<()> {
+    if path.is_file() {
+        Ok(())
+    } else {
+        Err(format!("missing required {component} file: {}", path.display()).into())
+    }
+}

--- a/gline-rs/src/model/gliner2/schema.rs
+++ b/gline-rs/src/model/gliner2/schema.rs
@@ -1,0 +1,52 @@
+use crate::text::splitter::Splitter;
+use crate::util::result::Result;
+
+use super::model::SpecialTokens;
+
+pub struct SchemaPrefix {
+    pub pieces: Vec<String>,
+    pub schema_piece_indices: Vec<usize>,
+}
+
+impl SchemaPrefix {
+    pub fn build_ner(
+        labels: &[String],
+        special_tokens: &SpecialTokens,
+        splitter: &impl Splitter,
+    ) -> Result<Self> {
+        let mut pieces = Vec::new();
+        let mut schema_piece_indices = Vec::with_capacity(1 + labels.len());
+
+        pieces.push("(".to_string());
+
+        schema_piece_indices.push(pieces.len());
+        pieces.push(special_tokens.prompt.clone());
+        pieces.push("entities".to_string());
+        pieces.push("(".to_string());
+
+        for label in labels {
+            schema_piece_indices.push(pieces.len());
+            pieces.push(special_tokens.entity.clone());
+
+            let label_tokens = splitter.split(label, None)?;
+            if label_tokens.is_empty() {
+                return Err(format!("invalid entity label: `{label}`").into());
+            }
+
+            pieces.extend(
+                label_tokens
+                    .into_iter()
+                    .map(|token| token.text().to_string()),
+            );
+        }
+
+        pieces.push(")".to_string());
+        pieces.push(")".to_string());
+        pieces.push(special_tokens.sep_text.clone());
+
+        Ok(Self {
+            pieces,
+            schema_piece_indices,
+        })
+    }
+}

--- a/gline-rs/src/model/gliner2/spans.rs
+++ b/gline-rs/src/model/gliner2/spans.rs
@@ -1,0 +1,38 @@
+pub fn build_span_idx(num_words: usize, max_width: usize) -> ndarray::Array3<i64> {
+    let mut span_idx = ndarray::Array::zeros((1, num_words * max_width, 2));
+
+    for start_word in 0..num_words {
+        let remaining_width = num_words.saturating_sub(start_word);
+        let valid_width = std::cmp::min(max_width, remaining_width);
+
+        for width in 0..valid_width {
+            let flat_index = start_word * max_width + width;
+            span_idx[[0, flat_index, 0]] = start_word as i64;
+            span_idx[[0, flat_index, 1]] = (start_word + width) as i64;
+        }
+    }
+
+    span_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_span_idx;
+
+    #[test]
+    fn pads_invalid_tail_widths_with_zeroes() {
+        let span_idx = build_span_idx(3, 4);
+
+        assert_eq!(span_idx.shape(), &[1, 12, 2]);
+        assert_eq!(span_idx[[0, 0, 0]], 0);
+        assert_eq!(span_idx[[0, 0, 1]], 0);
+        assert_eq!(span_idx[[0, 1, 0]], 0);
+        assert_eq!(span_idx[[0, 1, 1]], 1);
+        assert_eq!(span_idx[[0, 2, 0]], 0);
+        assert_eq!(span_idx[[0, 2, 1]], 2);
+        assert_eq!(span_idx[[0, 3, 0]], 0);
+        assert_eq!(span_idx[[0, 3, 1]], 0);
+        assert_eq!(span_idx[[0, 10, 0]], 0);
+        assert_eq!(span_idx[[0, 10, 1]], 0);
+    }
+}

--- a/gline-rs/src/model/gliner2/tokenizer.rs
+++ b/gline-rs/src/model/gliner2/tokenizer.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+use crate::util::result::Result;
+
+pub struct EncodedPieces {
+    pub input_ids: Vec<i64>,
+    pub attention_mask: Vec<i64>,
+    pub first_piece_positions: Vec<usize>,
+}
+
+#[derive(Clone)]
+pub struct GLiNER2Tokenizer {
+    inner: tokenizers::Tokenizer,
+}
+
+impl GLiNER2Tokenizer {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Ok(Self {
+            inner: tokenizers::Tokenizer::from_file(path)?,
+        })
+    }
+
+    pub fn token_to_id(&self, token: &str) -> Option<i64> {
+        self.inner.token_to_id(token).map(i64::from)
+    }
+
+    pub fn encode_pieces(&self, pieces: &[String]) -> Result<EncodedPieces> {
+        let piece_refs: Vec<&str> = pieces.iter().map(String::as_str).collect();
+        let encoding = self.inner.encode(piece_refs.as_slice(), false)?;
+
+        let mut first_piece_positions = vec![usize::MAX; pieces.len()];
+        for (token_index, piece_index) in encoding.get_word_ids().iter().enumerate() {
+            let Some(piece_index) = piece_index else {
+                continue;
+            };
+
+            let piece_index = *piece_index as usize;
+            if piece_index < first_piece_positions.len()
+                && first_piece_positions[piece_index] == usize::MAX
+            {
+                first_piece_positions[piece_index] = token_index;
+            }
+        }
+
+        if let Some((missing_index, _)) = first_piece_positions
+            .iter()
+            .enumerate()
+            .find(|(_, position)| **position == usize::MAX)
+        {
+            return Err(format!(
+                "tokenizer produced no tokens for schema/text piece #{missing_index}"
+            )
+            .into());
+        }
+
+        Ok(EncodedPieces {
+            input_ids: encoding.get_ids().iter().map(|id| i64::from(*id)).collect(),
+            attention_mask: encoding
+                .get_attention_mask()
+                .iter()
+                .map(|mask| i64::from(*mask))
+                .collect(),
+            first_piece_positions,
+        })
+    }
+}

--- a/gline-rs/src/model/mod.rs
+++ b/gline-rs/src/model/mod.rs
@@ -1,6 +1,7 @@
 //! The core of `gline-rs`: everything about pre-/post-processing, and inferencing
 
 pub mod config;
+pub mod gliner2;
 pub mod input;
 pub mod output;
 pub mod params;


### PR DESCRIPTION
  - add a dedicated `GLiNER2` runtime under `gline_rs/src/model/gliner2`.
  - implement schema-driven `GLiNER2` NER inference with internal tensor prep and span decoding
  - load `GLiNER2` models from `tokenizer.json` and ONNX without `gliner_config.json`
  - resolve `GLiNER2` special tokens directly from the tokenizer
  - pin `GLiNER2` span width to the ONNX-baked **max_width = 8**
  - add `PyFastGliNER2` to the Python extension backed by `GLiNER2`
  - reuse existing span-to-dict conversion for Python NER outputs
  - document GLiNER2 NER usage in the README